### PR TITLE
Expose postgres init script directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__
 .python-version
 nginx/ssl
+dbinit

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,6 @@ networks:
 
 volumes:
   dbdata:
-  dbinit:
 
 services:
   init-guac-db:
@@ -23,10 +22,10 @@ services:
       - |
         test -e /init/initdb.sql &&
         echo 'init file already exists' ||
-        /opt/guacamole/bin/initdb.sh --postgres > /init/initdb.sql
+        /opt/guacamole/bin/initdb.sh --postgres > /init/00_initdb.sql
     image: "guacamole/guacamole"
     volumes:
-      - "dbinit:/init"
+      - "./dbinit:/init"
 
   generate-nginx-ssl:
     command:
@@ -68,7 +67,7 @@ services:
       - source: postgres_username
         target: postgres-username
     volumes:
-      - "dbinit:/docker-entrypoint-initdb.d:ro"
+      - "./dbinit:/docker-entrypoint-initdb.d:ro"
       - "dbdata:/var/lib/postgresql/data:rw"
 
   guacamole:


### PR DESCRIPTION
The postgres docker image has a feature that allows [initialization scripts to be run](https://docs.docker.com/samples/library/postgres/#initialization-scripts) when the postgres container starts up with an empty data directory.  Guacamole takes advantage of this to create all of the necessary postgres users and tables that it needs to function.

Previously, this initialization directory was defined as a docker named volume.  This PR changes that to use a local directory to store these initialization scripts.  If the `./dbinit` directory is not present when this composition is started, it will be created by Docker.  

The primary use case for making this directory available locally is for downstream users to put their own custom startup scripts in.  For example, you could write a script that creates the necessary database entries for one or more Guacamole connections and then those connections would be available within Guacamole immediately after starting up this composition.