### PR TITLE
Make nginx listen on port 443

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ in this repository.
 To start the composition, use the command: `docker-compose up`
 
 Connect to the `guacamole` web interface at:
-[https://localhost:8443](https://localhost:8443).
+[https://localhost](https://localhost).
 The default credentials are `guacadmin`, `guacadmin` - you should change those
 as soon as possible.
 
@@ -27,7 +27,7 @@ as soon as possible.
 
 This composition exposes the following port to the localhost:
 
-- [8443](http://localhost:8443): `guacamole` web interface
+- [443](https://localhost): `guacamole` web interface
 
 ### Secrets ###
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -104,6 +104,9 @@ services:
         target: postgres-username
 
   nginx:
+    cap_add:
+      # Required to allow listening on privileged port 443
+      - NET_BIND_SERVICE
     command:
       - /bin/sh
       - -c
@@ -122,7 +125,7 @@ services:
     networks:
       guacnet:
     ports:
-      - 8443:443
+      - 443:443
     restart: always
     volumes:
       - type: bind


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description
This PR changes the port that nginx listens on from 8443 to 443.

Resolves #2 .
<!--- Describe your changes in detail -->

## 💭 Motivation and Context
Currently, the `nginx` service in the Docker composition listens on port 8443, which means that end users of Guacamole must use a URL like `https://guac.mydomain.gov:8443`.  This PR simplifies things so that the URL will be `https://guac.mydomain.gov`.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing
I ran `docker-compose up` on my development machine and verified that I was able to successfully access Guacamole by browsing to `https://localhost`.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
