### PR TITLE
Add a blurb explaining the temporary use of a custom Docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,22 @@ remote desktop gateway.
 Guacamole.
 - [Postgres](https://hub.docker.com/_/postgres/) relational database.
 
+## Nota bene ##
+
+We currently use [a custom version of the Guacamole Docker
+image](https://hub.docker.com/r/cisagov/guacamole) mentioned above.
+This is because the official Guacamole Docker image does not include
+[the `guacamole-auth-header-*.jar` file that is required to provide
+header-based
+authentication](https://guacamole.apache.org/doc/gug/header-auth.html).
+We use header-based authentication in order to leverage our Kerberos
+setup via an Apache web proxy.  This functionality will be added to
+the official Guacamole Docker image in Docker Hub with the next
+release of Guacamole, at which time we can revert to using the
+official Docker image.  See
+[apache/guacamole-client#548](https://github.com/apache/guacamole-client/pull/548)
+for more details.
+
 ## Usage ##
 
 A sample [Docker composition](docker-compose.yml) is included


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds a blurb explaining the temporary use of a custom Docker image.

## 💭 Motivation and Context ##

@dav3r noticed that we are using [`cisagov/guacamole`](https://hub.docker.com/r/cisagov/guacamole) instead of [`guacamole/guacamole`](https://hub.docker.com/r/guacamole/guacamole) in `docker-compose.yml`.  We couldn't remember why that was so, nor could we find a repository in [the cisagov GitHub organization](https://github.com/cisagov) that generated the custom image.

Eventually we realized that the custom Guacamole Docker image was a temporary measure, and that [the necessary changes had been made to the Guacamole project](https://github.com/apache/guacamole-client/pull/548) to obviate the need for a custom Docker image once a new version of Guacamole is released.  That release should become reality something in January 2021.  (We didn't expect it to take over six months for a new Guacamole release to come out.)

To avoid future confusion, and since I had to work pretty hard to retrace my steps from July, I added a blurb to `README.md` explaining why the custom image is used and when we can revert to using the official Docker image.

## 🧪 Testing ##

I looked at the rendering of the Markdown and was pleased.

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
* [x] All new and existing tests pass.
