### PR TITLE
Integrate guacscanner

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,10 @@ remote desktop gateway.
 - [guacd](https://hub.docker.com/r/guacamole/guacd/) server-side proxy for
 Guacamole.
 - [Postgres](https://hub.docker.com/_/postgres/) relational database.
-- [cisagov/guacscanner-docker](cisagov/guacscanner-docker) utility for
-  continually scanning the EC2 instances in an AWS VPC and updating the
-  Guacamole connections in the underlying PostgreSQL database.
+- [cisagov/guacscanner-docker](https://github.com/cisagov/guacscanner-docker)
+  utility for continually scanning the EC2 instances in an AWS VPC and
+  updating the Guacamole connections in the underlying PostgreSQL
+  database.
 
 ## Running ##
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ remote desktop gateway.
 - [guacd](https://hub.docker.com/r/guacamole/guacd/) server-side proxy for
 Guacamole.
 - [Postgres](https://hub.docker.com/_/postgres/) relational database.
+- [cisagov/guacscanner-docker](cisagov/guacscanner-docker) utility for
+  continually scanning the instances in an AWS VPC and updating the
+  Guacamole connections in the underlying PostgreSQL database.
 
 ## Running ##
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ composition on a publicly-accessible host:
 |----------|---------|
 | postgres-username | Text file containing the username of the `postgres` user used by the `guacamole` container |
 | postgres-password | Text file containing the password of the `postgres` user used by the `guacamole` container |
-| private_ssh_key | Text file containing the private ssh key to use for SFTP file transfer in Guacamole. |
+| private_ssh_key | Text file containing the private SSH key to use for SFTP file transfer in Guacamole. |
 | rdp_username | Text file containing the username for Guacamole to use when connecting to an instance via RDP. |
 | rdp_password | Text file containing the password for Guacamole to use when connecting to an instance via RDP. |
 | vnc_username | Text file containing the username for Guacamole to use when connecting to an instance via VNC. |

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ remote desktop gateway.
 Guacamole.
 - [Postgres](https://hub.docker.com/_/postgres/) relational database.
 - [cisagov/guacscanner-docker](cisagov/guacscanner-docker) utility for
-  continually scanning the instances in an AWS VPC and updating the
+  continually scanning the EC2 instances in an AWS VPC and updating the
   Guacamole connections in the underlying PostgreSQL database.
 
 ## Running ##

--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ composition on a publicly-accessible host:
 |----------|---------|
 | postgres-username | Text file containing the username of the `postgres` user used by the `guacamole` container |
 | postgres-password | Text file containing the password of the `postgres` user used by the `guacamole` container |
+| private_ssh_key | Text file containing the private ssh key to use for SFTP file transfer in Guacamole. |
+| rdp_username | Text file containing the username for Guacamole to use when connecting to an instance via RDP. |
+| rdp_password | Text file containing the password for Guacamole to use when connecting to an instance via RDP. |
+| vnc_username | Text file containing the username for Guacamole to use when connecting to an instance via VNC. |
+| vnc_password | Text file containing the password for Guacamole to use when connecting to an instance via VNC. |
 
 ## Contributing ##
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,10 @@ services:
       POSTGRES_DB: guacamole_db
       POSTGRES_PASSWORD_FILE: /run/secrets/postgres-password
       POSTGRES_USER_FILE: /run/secrets/postgres-username
-    image: postgres
+    # The version of the JDBC PostgreSQL driver included in the
+    # Guacamole Docker image is too old to work with PostgreSQL 14 or
+    # later.
+    image: postgres:13
     restart: always
     secrets:
       - source: postgres_password

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,16 @@ secrets:
     file: ./src/secrets/postgres-password
   postgres_username:
     file: ./src/secrets/postgres-username
+  private_ssh_key:
+    file: ./src/secrets/private-ssh-key
+  rdp_password:
+    file: ./src/secrets/rdp-password
+  rdp_username:
+    file: ./src/secrets/rdp-username
+  vnc_password:
+    file: ./src/secrets/vnc-password
+  vnc_username:
+    file: ./src/secrets/vnc-username
 
 volumes:
   dbdata:
@@ -78,3 +88,23 @@ services:
         target: postgres-password
       - source: postgres_username
         target: postgres-username
+
+  guacscanner:
+    depends_on:
+      - postgres
+    image: cisagov/guacscanner
+    secrets:
+      - source: postgres_password
+        target: postgres-password
+      - source: postgres_username
+        target: postgres-username
+      - source: private_ssh_key
+        target: private-ssh-key
+      - source: rdp_password
+        target: rdp-password
+      - source: rdp_username
+        target: rdp-username
+      - source: vnc_password
+        target: vnc-password
+      - source: vnc_username
+        target: vnc-username

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,8 +47,8 @@ services:
       POSTGRES_PASSWORD_FILE: /run/secrets/postgres-password
       POSTGRES_USER_FILE: /run/secrets/postgres-username
     # The version of the JDBC PostgreSQL driver included in the
-    # Guacamole Docker image is too old to work with PostgreSQL 14 or
-    # later.
+    # Guacamole Docker image (the one tagged "latest", as of November
+    # 5, 2021) is too old to work with PostgreSQL 14 or later.
     image: postgres:13
     restart: always
     secrets:

--- a/src/secrets/private-ssh-key
+++ b/src/secrets/private-ssh-key
@@ -1,0 +1,1 @@
+my_private_ssh_key

--- a/src/secrets/rdp-password
+++ b/src/secrets/rdp-password
@@ -1,0 +1,1 @@
+my_rdp_password

--- a/src/secrets/rdp-username
+++ b/src/secrets/rdp-username
@@ -1,0 +1,1 @@
+my_rdp_username

--- a/src/secrets/vnc-password
+++ b/src/secrets/vnc-password
@@ -1,0 +1,1 @@
+my_vnc_password

--- a/src/secrets/vnc-username
+++ b/src/secrets/vnc-username
@@ -1,0 +1,1 @@
+my_vnc_username

--- a/tests/container_test.py
+++ b/tests/container_test.py
@@ -21,7 +21,7 @@ def test_container_count(dockerc):
 
 def test_wait_for_ready_guacamole(guacamole_container):
     """Wait for guacamole container to be ready."""
-    TIMEOUT = 10
+    TIMEOUT = 20
     ready_message = READY_MESSAGES["guacamole"]
     for i in range(TIMEOUT):
         if ready_message in guacamole_container.logs().decode("utf-8"):

--- a/tests/container_test.py
+++ b/tests/container_test.py
@@ -15,7 +15,7 @@ def test_container_count(dockerc):
     """Verify the test composition and container."""
     # stopped parameter allows non-running containers in results
     assert (
-        len(dockerc.containers(stopped=True)) == 4
+        len(dockerc.containers(stopped=True)) == 5
     ), "Wrong number of containers were started."
 
 


### PR DESCRIPTION
## 🗣 Description ##

This pull request integrates [cisagov/guacscanner-docker](https://github.com/cisagov/guacscanner-docker) into this Docker composition.

## 💭 Motivation and context ##

The functionality of [cisagov/guacscanner](https://github.com/cisagov/guacscanner) must be integrated into this Docker composition for the RPT UAT taking place in the COOL.

See also:
- cisagov/guacscanner/pull/1
- cisagov/guacscanner-docker#2
- cisagov/ansible-role-guacamole#38
- cisagov/guacamole-packer#53
- cisagov/cool-assessment-terraform#149

## 🧪 Testing ##

I have applied these changes to env0 in our staging COOL environment and verified that they function as expected.

## ✅ Checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
