### PR TITLE
Update cisagov/guascanner version used

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ composition on a publicly-accessible host:
 | rdp_password | Text file containing the password for Guacamole to use when connecting to an instance via RDP. |
 | vnc_username | Text file containing the username for Guacamole to use when connecting to an instance via VNC. |
 | vnc_password | Text file containing the password for Guacamole to use when connecting to an instance via VNC. |
+| windows_sftp_base | Text file containing the base path for the SFTP directories that Guacamole will use when connecting to a Windows instance via VNC. |
 
 ## Contributing ##
 

--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ composition on a publicly-accessible host:
 
 | Filename | Purpose |
 |----------|---------|
-| postgres-username | Text file containing the username of the `postgres` user used by the `guacamole` container |
-| postgres-password | Text file containing the password of the `postgres` user used by the `guacamole` container |
+| postgres_username | Text file containing the username of the `postgres` user used by the `guacamole` container |
+| postgres_password | Text file containing the password of the `postgres` user used by the `guacamole` container |
 | private_ssh_key | Text file containing the private SSH key to use for SFTP file transfer in Guacamole. |
 | rdp_username | Text file containing the username for Guacamole to use when connecting to an instance via RDP. |
 | rdp_password | Text file containing the password for Guacamole to use when connecting to an instance via RDP. |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,7 +97,7 @@ services:
   guacscanner:
     depends_on:
       - postgres
-    image: cisagov/guacscanner:1.0.0
+    image: cisagov/guacscanner:1.1.0-rc.1
     secrets:
       - source: postgres_password
         target: postgres-password

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,8 @@ secrets:
     file: ./src/secrets/vnc-password
   vnc_username:
     file: ./src/secrets/vnc-username
+  windows_sftp_base:
+    file: ./src/secrets/windows-sftp-base
 
 volumes:
   dbdata:
@@ -111,3 +113,5 @@ services:
         target: vnc-password
       - source: vnc_username
         target: vnc-username
+      - source: windows_sftp_base
+        target: windows-sftp-base

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,7 +97,7 @@ services:
   guacscanner:
     depends_on:
       - postgres
-    image: cisagov/guacscanner
+    image: cisagov/guacscanner:1.0.0
     secrets:
       - source: postgres_password
         target: postgres-password

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,7 +97,7 @@ services:
   guacscanner:
     depends_on:
       - postgres
-    image: cisagov/guacscanner:1.1.0-rc.1
+    image: cisagov/guacscanner:1.1.0-rc.2
     secrets:
       - source: postgres_password
         target: postgres-password

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,7 +97,7 @@ services:
   guacscanner:
     depends_on:
       - postgres
-    image: cisagov/guacscanner:1.1.0-rc.2
+    image: cisagov/guacscanner:1.1.0
     restart: always
     secrets:
       - source: postgres_password

--- a/src/secrets/windows-sftp-base
+++ b/src/secrets/windows-sftp-base
@@ -1,0 +1,1 @@
+/C:/Users/my_vnc_username


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR adds a version pin that uses the latest version of [cisagov/guacscanner] as well as adding the necessary elements to support the changes. These changes are implemented in https://github.com/cisagov/guacscanner/pull/16.

It also updates the README to fix two secrets with incorrect names.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

With the changes in https://github.com/cisagov/guacscanner/pull/16 to connect to Windows instances using VNC there needs to be an additional secret for the [Docker container version](https://github.com/cisagov/guacscanner-docker) of [cisagov/guacscanner].
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I deployed this composition into my staging environment and things worked as expected.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

- [x] Update [cisagov/guacscanner] version to finalized version

[cisagov/guacscanner]: https://github.com/cisagov/guacscanner