### PR TITLE
Modify Docker composition to always restart the guacscanner service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -96,6 +96,7 @@ services:
     depends_on:
       - postgres
     image: cisagov/guacscanner
+    restart: always
     secrets:
       - source: postgres_password
         target: postgres-password


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies the Docker composition to always restart the `guacscanner` service if it exits.

## 💭 Motivation and context ##

This will make the Docker composition more resilient to ephemeral and prolonged error conditions such as the AWS outage that we experienced yesterday.  Resolves cisagov/cool-system-internal#70.

## 🧪 Testing ##

All `pre-commit` hooks pass.

## ✅ Checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
