### PR TITLE
Use the latest guacscanner Docker image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,7 +97,7 @@ services:
   guacscanner:
     depends_on:
       - postgres
-    image: cisagov/guacscanner:1.1.0
+    image: cisagov/guacscanner:1.1.1-rc.1
     restart: always
     secrets:
       - source: postgres_password

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,7 +97,7 @@ services:
   guacscanner:
     depends_on:
       - postgres
-    image: cisagov/guacscanner:1.1.1-rc.1
+    image: cisagov/guacscanner:1.1.1
     restart: always
     secrets:
       - source: postgres_password


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies the Docker composition to use the latest [`guacscanner` Docker image](https://github.com/cisagov/guacscanner-docker).

## 💭 Motivation and context ##

We need to include the latest [`guacscanner` Docker image](https://github.com/cisagov/guacscanner-docker) in the composition in order to test it.

## 🧪 Testing ##

I created a new [`guacscanner` AMI](https://github.com/guacamole-packer) for our COOL staging environment with these changes and verified that the file share symlink is now interpreted correctly.

## ✅ Checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
