### PR TITLE
Fix reference to docker-compose in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Guacamole.
 A sample [Docker composition](docker-compose.yml) is included
 in this repository.
 
-To start the composition, use the command: `docker-compose up`
+To start the composition, use the command: `docker compose up`
 
 Connect to the Guacamole web interface at:
 [http://localhost/guacamole](http://localhost/guacamole).


### PR DESCRIPTION
## 🗣 Description ##

This pull request updates `README.md` to use the `docker compose` syntax instead of the `docker-compose` syntax.

## 💭 Motivation and context ##

The `docker compose` syntax is the preferred (and only correct) syntax after the changes in cisagov/ansible-role-docker#60.

## 🧪 Testing ##

Automated testing passes.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.